### PR TITLE
Move composable-helpers to dependencies

### DIFF
--- a/blueprints/empress-blog-starter-template/index.js
+++ b/blueprints/empress-blog-starter-template/index.js
@@ -10,6 +10,7 @@ module.exports = {
       return this.addAddonsToProject({
         packages: [
           'ember-cli-htmlbars',
+          'ember-composable-helpers',
         ],
         blueprintOptions: {
           save: true
@@ -19,7 +20,6 @@ module.exports = {
     .then(() => {
       return this.addAddonsToProject({
         packages: [
-          'ember-composable-helpers',
           'ember-data',
           'ember-fetch',
         ]


### PR DESCRIPTION
When creating a new template the default example uses some helpers from `ember-composable-helpers` but they weren't in the dependencies. That means that when you publish and consume your template it won't work out of the box 😢  this should fix that 🎉 